### PR TITLE
Travis configuration for heroku dod packagecloud

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,27 @@
+language: cpp
+sudo: required
+dist: trusty
+env:
+  global:
+    secure: adkro9qIBnG0Iilmn4QmcgpyPbYlJnF/KpLDKKbFu3NRcZNgaAiHDMa4MzSyWexFeW6BExYBYfdbgPm2vmGvfptM51TrBR2TbrCRVOlq+l6Iv0nc/eXfbnz4HDMHmc1l26HWd0/FAJkYZlvBCY2NMjL5rIXm3aJZn1JurfNxsNh4uC5ge4hcIeWn3K5HfR39tqyO1A5Y2Qqw4A3R5h6em4GdR4ZEVffAJFDkejcdx0h5aON+NGXXuhtVRYHp2IOpcf3RO1bdCpZXrxM+NpQbN6NsDAS7xZt4oIMd0Q/hBUHyVxqhRQpvDftbO4hm5kWXxf6ffoUETR9ebUe4rUZ1EUiEOa23/KHBFUzxuG7wCg/k5X1J50o6+5Kydkeef+qRqR6qMmezlwXyXhh2k/0Jj0rN4LqkNU49y/9bXhat/oVTE2R0xLH3BbNjK9HCGKLXMs1GJAiywZDkGZXiyHaRh14tbgXTKiJkkSKX5wEauxbBOkWIiCiShWx85JSUUjT6jH6xi8UshEa3Uhxhv4aWuH0Apv+f0nABdNkDRX+WL/8DYWYr6t4iLjoKe9PfGs/NGx9L0YPq6fOY1cMmr/h1hGPeMvyncxg6Lj+BR8Wix7TU1QEdDIgw4cKAKenwvSSa/BvDmIGNX7V91OI0OLD4UNu0hloPv1YYR+kb9noQqT0=
+before_install:
+- wget --quiet -O - https://packagecloud.io/gpg.key | sudo apt-key add -
+- curl -s https://${TOKEN}:@packagecloud.io/install/repositories/heroku/dod/script.deb.sh
+  | sudo bash
+- sudo apt-get update
+- sudo apt-get -y --force-yes install debhelper devscripts postgresql-server-dev-all
+before_script:
+- make clean
+script:
+- make deb
+deploy:
+- provider: packagecloud
+  dist: ubuntu/trusty
+  package_glob: build/*.deb
+  username: heroku
+  repository: dod
+  token:
+    secure: Ts66jfdhEZ0fw3LqXrYG/lwDAsi0ptiyYWGHMR8tSYaR/EB1QVStySG9/IcbJ8NkNEyq/ywykp5f5Naug75nwvYZCfRfKeUeZrllkFy0LzMHtQx2lw+yM6CVs7a/yuFKZeVgZcT2F2ktpwGPNvcY1HP/2d2zeIdTHB/rucYymfAsen0ylt7n1Z41p6WYGnaTYr6e4KgUB2FE4xzB7PZ99IXnbGtSl15wiI5rOw+Kt3KVyRIfr/MdvGtZoDVpthtiorWG4zMDjj7uo8NqIHMUtzE4LeSQukCO7S0GlS8timYCJ5VIBUY1Kr0Me44Rr4ip1vBdZ0PMit08PR9t8/VkKNtmvGRQW17Yw/ULmC5a6ao+LwYVzTkDQVerKDpMJMxvsgpV+sUwZx/PejjlICbWiickXc8vMtRfGogn0+oM0LPx8OIjY9qfud/aad0Xoa1/t4b+bVZAMUS7i3K2ffDN4/6gMww2x3LTekuijBWmm/X+RRlt9B9rrcqlSt0W/3OJCtsVIR0eQ7amGfcpfP2PYf22LSjL/rZo4lglqOjFD+k9zR7DhtbJyYtjabGDoMKETJ69ho1OIs5vXvCuqJ1zxRht3NLStHgymbaCCVgiG5cP4pbUp/QpT+JejOQpELGCl5SR3h1MImjctf1daBQiSxkI1Uv1eVRCXqNeFdrcluc=
+  skip_cleanup: true
+notifications:
+  email: false


### PR DESCRIPTION
Travis configuration to publish the amcheck package in the heroku dod packagecloud. 
Happy to move this to a heroku-specific fork of this repo if you feel that's more suitable. 
