### PR TITLE
Normalize building 9.6 packages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,10 +7,9 @@ env:
     - DIST=trusty
 before_install:
   - sudo apt-get -y install wget software-properties-common
-  - sudo add-apt-repository -y "deb http://apt.postgresql.org/pub/repos/apt/ trusty-pgdg main 9.6" && wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
+  - sudo add-apt-repository -y "deb http://apt.postgresql.org/pub/repos/apt/ trusty-pgdg main" && wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
   - sudo apt-get update
-  - sudo apt-get -y --force-yes install debhelper devscripts postgresql-server-dev-all postgresql-server-dev-9.6
-  - echo '9.4\n9.5\n9.6' > ~/.pg_supported_versions
+  - sudo apt-get -y --force-yes install debhelper devscripts postgresql-server-dev-all
 before_script:
   - make clean
 script:

--- a/debian/control
+++ b/debian/control
@@ -1,7 +1,7 @@
 Source: amcheck
 Priority: extra
 Maintainer: Peter Geoghegan <pg@bowt.ie>
-Build-Depends: debhelper (>= 9), postgresql-server-dev-all (>= 171~), postgresql-server-dev-9.6
+Build-Depends: debhelper (>= 9), postgresql-server-dev-all (>= 177~)
 Standards-Version: 3.9.6
 Section: database
 Homepage: https://github.com/petergeoghegan/amcheck

--- a/debian/control.in
+++ b/debian/control.in
@@ -1,7 +1,7 @@
 Source: amcheck
 Priority: extra
 Maintainer: Peter Geoghegan <pg@bowt.ie>
-Build-Depends: debhelper (>= 9), postgresql-server-dev-all (>= 171~)
+Build-Depends: debhelper (>= 9), postgresql-server-dev-all (>= 177~)
 Standards-Version: 3.9.6
 Section: database
 Homepage: https://github.com/petergeoghegan/amcheck

--- a/debian/tests/control
+++ b/debian/tests/control
@@ -1,3 +1,3 @@
-Depends: @, postgresql-server-dev-9.4, postgresql-server-dev-9.5, postgresql-server-dev-9.6, postgresql-contrib-9.4, postgresql-contrib-9.5, postgresql-contrib-9.6
+Depends: @, postgresql-server-dev-all, postgresql-contrib-9.4, postgresql-contrib-9.5, postgresql-contrib-9.6
 Tests: installcheck
 Restrictions: allow-stderr

--- a/debian/tests/control.in
+++ b/debian/tests/control.in
@@ -1,3 +1,3 @@
-Depends: @, postgresql-server-dev-PGVERSION, postgresql-contrib-PGVERSION
+Depends: @, postgresql-server-dev-all, postgresql-contrib-PGVERSION
 Tests: installcheck
 Restrictions: allow-stderr


### PR DESCRIPTION
Previously in af8b090 and 55eae4b there was some thrashing done to be
able to build packages for a postgres server version that was not served
by postgres-server-dev-all package.

This commit removes that thrashing and updates the required
postgres-server-dev-all package version to latest, which allows building
of extensions for 9.6 without gymnastics.
