### PR TITLE
Error code for heap_all_indexed

### DIFF
--- a/verify_nbtree.c
+++ b/verify_nbtree.c
@@ -1313,7 +1313,7 @@ bt_tuple_present_callback(Relation index, HeapTuple htup, Datum *values,
 	if (bloom_lacks_element(state->filter, (unsigned char *) itup,
 							IndexTupleSize(itup)))
 		ereport(ERROR,
-				(errcode(ERRCODE_DATA_CORRUPTED),
+				(errcode(ERRCODE_INDEX_CORRUPTED),
 				 errmsg("heap tuple (%u,%u) from table \"%s\" lacks matching index tuple within index \"%s\"",
 						ItemPointerGetBlockNumber(&(itup->t_tid)),
 						ItemPointerGetOffsetNumber(&(itup->t_tid)),


### PR DESCRIPTION
Hi! Here's one more small spot. I think it's better to use ERRCODE_INDEX_CORRUPTED instead of ERRCODE_DATA_CORRUPTED in heap_all_indexed check. We are not sure data is corrupted, but the index is certainly invalid.