### PR TITLE
Remove unnecessary XS-Testsuite field in debian/control.

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+amcheck (1.4-2) UNRELEASED; urgency=medium
+
+  * Remove unnecessary XS-Testsuite field in debian/control.
+
+ -- Jelmer Vernooĳ <jelmer@debian.org>  Tue, 11 Sep 2018 00:01:45 +0100
+
 amcheck (1.4-1) unstable; urgency=medium
 
   * Add missing and dangling downlink checks from PostgreSQL 11 devel.

--- a/debian/control
+++ b/debian/control
@@ -7,7 +7,6 @@ Section: database
 Homepage: https://github.com/petergeoghegan/amcheck
 Vcs-Git: https://github.com/petergeoghegan/amcheck.git
 Vcs-Browser: https://github.com/petergeoghegan/amcheck
-XS-Testsuite: autopkgtest
 
 Package: postgresql-9.4-amcheck
 Section: libs


### PR DESCRIPTION
Remove unnecessary XS-Testsuite field in debian/control.

Fixes lintian: xs-testsuite-field-in-debian-control
See https://lintian.debian.org/tags/xs-testsuite-field-in-debian-control.html for more details.
